### PR TITLE
Simple change to throw on MongoDB connection error

### DIFF
--- a/sperm-whale/database.js
+++ b/sperm-whale/database.js
@@ -3,6 +3,10 @@ const MongoClient = require('mongodb').MongoClient;
 const url = process.env.MONGO_URL || 'mongodb://localhost:27017/test';
 
 MongoClient.connect(url, function(err, db) {
+  if (err) {
+    throw err;
+  }
+
   console.log(`Connected to MongoDB @${url}`);
   const courses = db.collection('courses');
   const buildings = db.collection('buildings');


### PR DESCRIPTION
Should help diagnose issues better than trying to access a `connection` which may not exist